### PR TITLE
Ensure we can interact with reloaded lists

### DIFF
--- a/features/progressive-web-application.feature
+++ b/features/progressive-web-application.feature
@@ -8,6 +8,7 @@ Feature: Progressive Web Application
     Given my task list has a few items due
     When I leave and come back
     Then my list is still there
+    And I can interact with my list
 
   Scenario: Hide the list on log out
     Given I am logged in

--- a/features/steps/all.rb
+++ b/features/steps/all.rb
@@ -123,6 +123,12 @@ Then("I can see my list again") do
   expect(list.map { |item| item.name }).to eq remember_the_list
 end
 
+Then("I can interact with my list") do
+  expect(last_item_mentioned.phase).to be :due
+  complete_the_item!
+  expect(last_item_mentioned.phase).to be :complete
+end
+
 Given("I am logged in") do
   log_in
 end

--- a/features/support/world.rb
+++ b/features/support/world.rb
@@ -10,15 +10,27 @@ class Item
   end
 
   def name
-    li.find("label").text
+    unless obsolete?
+      @name = li.find("label").text
+    end
+
+    @name
   end
 
   def phase
-    if li.find("input[type=checkbox]").checked?
-      :complete
-    elsif li[:class] == "item-due"
-      :due
+    unless obsolete?
+      @phase = if li.find("input[type=checkbox]").checked?
+        :complete
+      elsif li[:class] == "item-due"
+        :due
+      end
     end
+
+    @phase
+  end
+
+  def obsolete?
+    li.inspect.start_with? "Obsolete"
   end
 
   def inspect
@@ -110,7 +122,9 @@ module KnowsTheUI
   end
 
   def reload_the_page
+    name = last_item_mentioned.name
     visit("/")
+    get_item_by_name(name)
   end
 
   def log_in

--- a/web/src/List.js
+++ b/web/src/List.js
@@ -5,11 +5,17 @@ class List extends React.Component {
   constructor (props) {
     super(props)
 
+    const initItems = () => {
+      if (props.initItems) return props.initItems
+
+      const localItems = JSON.parse(window.localStorage.getItem('items'))
+      if (localItems) return localItems
+      return []
+    }
+
     this.state = {
       newItemForm: '',
-      items: (props.initItems)
-        ? props.initItems.map(item => { return new AbstractItem(item) })
-        : JSON.parse(window.localStorage.getItem('items')) || []
+      items: initItems().map(item => { return new AbstractItem(item) })
     }
   }
 

--- a/web/src/List.test.js
+++ b/web/src/List.test.js
@@ -5,13 +5,16 @@ import List from './List'
 
 describe('a list with no attributes set', () => {
   test('maintains state between renders', () => {
-    render(<List />)
+    const { unmount } = render(<List />)
     userEvent.click(getButtonAddItem())
     userEvent.type(activeElement(), 'wash dishes{enter}')
     expect(queryListItem(/wash dishes/i)).toBeDue()
 
+    unmount()
     render(<List />)
     expect(queryListItem(/wash dishes/i)).toBeDue()
+    userEvent.click(getButton(/dismiss wash dishes/i))
+    expect(queryListItem(/wash dishes/i)).toBeNull()
   })
 })
 


### PR DESCRIPTION
When I added persistence, I messed up and didn't ensure the items pulled
from localStorage were actually AbstractItems, and so they weren't, and
so they lacked the copyItem() method. This is fixed now.