### PR TITLE
Test that web/.node-version matches dockerfiles

### DIFF
--- a/web/Dockerfile.serve
+++ b/web/Dockerfile.serve
@@ -5,8 +5,11 @@
 FROM node:17.3.0 as builder
 
 WORKDIR /usr/src/app
-COPY package.json yarn.lock ./
-RUN apt-get update && yarn install
+COPY .node-version package.json yarn.lock ./
+RUN node --version | sed -e 's/^v//' > /tmp/node-version \
+      && diff .node-version /tmp/node-version \
+      && apt-get update \
+      && yarn install
 COPY ./public public/
 COPY ./src src/
 


### PR DESCRIPTION
The actual deployment only cares about the value of that file, but
dependabot only updates the dockerfiles. With this change, dependabot's
pull requests still won't update the .node-version file, but now at
least the tests will fail when that happens.